### PR TITLE
Include shell-pop group to shell group

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -49,7 +49,8 @@
 (require 'term)
 
 (defgroup shell-pop ()
-  "Shell-pop")
+  "Shell-pop"
+  :group 'shell)
 
 ;; internal{
 (defvar shell-pop-internal-mode "shell")


### PR DESCRIPTION
I think `shell-pop` group should be included in `shell` group.
