### PR TITLE
Backward compability

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -144,6 +144,26 @@ buffer from which the `shell-pop' command was invoked."
              shell-pop-universal-key)
     (define-key term-raw-map (read-kbd-macro value) 'shell-pop)))
 
+
+;;; backward compatible setter custom
+;; extracted from emacs wiki last version, and adapted (keep api, change intern)
+
+(defun shell-pop-set-window-height (number)
+  (interactive "nInput the number for the percentage of \
+selected window height (10-100): ")
+  (setq shell-pop-window-height number))
+
+(defun shell-pop-set-window-position (position)
+  (interactive "sInput the position for shell-pop (top|bottom|full): ")
+  (setq shell-pop-window-position position))
+;; §later: checkying
+
+(defun shell-pop-set-internal-mode-shell (shell)
+  (interactive (list (read-from-minibuffer "Input your favorite shell:"
+                                           shell-pop-term-shell)))
+  (setq shell-pop-term-shell shell))
+
+
 ;;;###autoload
 (defcustom shell-pop-universal-key nil
   "Key binding used to pop in and out of the shell.

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -169,24 +169,31 @@ buffer from which the `shell-pop' command was invoked."
 (defun shell-pop-set-window-height (number)
   (interactive "nInput the number for the percentage of \
 selected window height (10-100): ")
-  (setq shell-pop-window-height number))
+  (if  (and (<= number 100) (<= 0 number))
+      (setq shell-pop-window-height number)
+    (message "Height not in range: %d, must be between 0 and 100" number)))
 
 (defun shell-pop-set-window-position (position)
   (interactive "sInput the position for shell-pop (top|bottom|full): ")
-  (setq shell-pop-window-position position))
-;; §later: checkying
+  (if (string-match-p "^\\(top\\|bottom\\|full\\)$" position)
+      (setq shell-pop-window-position position)
+    (message "Invalid positif: acceptables values: top|bottom|full")))
+;; §later: completion?
 
 (defun shell-pop-set-internal-mode-shell (shell)
   (interactive (list (read-from-minibuffer "Input your favorite shell:"
                                            shell-pop-term-shell)))
   (setq shell-pop-term-shell shell))
 
-(defun shell-pop-set-internal-mode (mode)
+(defun shell-pop-change-shell-mode (mode)
   (interactive "sInput your favorite mode (shell|terminal|ansi-term|eshell): ")
   (let  ((shell-mode (shell-pop--get-default-shell-type mode)))
-    (when shell-mode
-     (shell-pop--set-shell-type 'shell-pop-shell-type shell-mode))))
+    (if shell-mode
+     (shell-pop--set-shell-type 'shell-pop-shell-type shell-mode)
+     (message "Shell mode %s does not exist" mode))))
 
+(defalias 'shell-pop-set-internal-mode 'shell-pop-change-shell-mode
+  "Backward compatible alias")
 
 ;;;###autoload
 (defcustom shell-pop-universal-key nil

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -97,6 +97,23 @@
   :type 'directory
   :group 'shell-pop)
 
+
+(defconst shell-pop-shell-type-alist
+  ;; name --> mode, buffer, function
+  '(("shell"     . ("shell"     "*shell*"
+		    '(lambda () (shell))))
+    ("terminal"  . ("terminal"  "*terminal*"
+		    '(lambda () (term shell-pop-term-shell))))
+    ("ansi-term" . ("ansi-term" "*ansi-term*"
+		      '(lambda () (ansi-term shell-pop-term-shell))))
+    ("eshell"    . ("eshell"    "*eshell*"
+		    '(lambda () (eshell)))))
+    "Shell default default types alist")
+
+(defun shell-pop--get-default-shell-type (name)
+  "Get one of predefined shell type by NAME"
+  (cdr-safe (assoc name shell-pop-shell-type-alist)))
+
 (defun shell-pop--set-shell-type (symbol value)
   (set-default symbol value)
   (setq shell-pop-internal-mode (nth 0 value)
@@ -106,23 +123,23 @@
              shell-pop-universal-key)
     (define-key term-raw-map (read-kbd-macro shell-pop-universal-key) 'shell-pop)))
 
-(defcustom shell-pop-shell-type '("shell" "*shell*" (lambda () (shell)))
+(defcustom shell-pop-shell-type (shell-pop--get-default-shell-type "shell")
   "Type of shell that is launched when first popping into a shell.
 
 The value is a list with these items:
  - Internal name of the shell type.  This should be unique \"id\".
  - Name of the buffer this shell opens.
  - A function that launches the shell."
-  :type '(choice
+  :type `(choice
           (list :tag "Custom" string string function)
           (const :tag "shell"
-                 ("shell" "*shell*" (lambda () (shell))))
+                 ,(shell-pop--get-default-shell-type "shell"))
           (const :tag "terminal"
-                 ("terminal" "*terminal*" (lambda () (term shell-pop-term-shell))))
+                 ,(shell-pop--get-default-shell-type "terminal"))
           (const :tag "ansi-term"
-                 ("ansi-term" "*ansi-term*" (lambda () (ansi-term shell-pop-term-shell))))
+                 ,(shell-pop--get-default-shell-type "ansi-term"))
           (const :tag "eshell"
-                 ("eshell" "*eshell*" (lambda () (eshell)))))
+                 ,(shell-pop--get-default-shell-type "eshell")))
   :set 'shell-pop--set-shell-type
   :group 'shell-pop)
 
@@ -148,6 +165,7 @@ buffer from which the `shell-pop' command was invoked."
 ;;; backward compatible setter custom
 ;; extracted from emacs wiki last version, and adapted (keep api, change intern)
 
+
 (defun shell-pop-set-window-height (number)
   (interactive "nInput the number for the percentage of \
 selected window height (10-100): ")
@@ -162,6 +180,12 @@ selected window height (10-100): ")
   (interactive (list (read-from-minibuffer "Input your favorite shell:"
                                            shell-pop-term-shell)))
   (setq shell-pop-term-shell shell))
+
+(defun shell-pop-set-internal-mode (mode)
+  (interactive "sInput your favorite mode (shell|terminal|ansi-term|eshell): ")
+  (let  ((shell-mode (shell-pop--get-default-shell-type mode)))
+    (when shell-mode
+     (shell-pop--set-shell-type 'shell-pop-shell-type shell-mode))))
 
 
 ;;;###autoload


### PR DESCRIPTION
I have been using shell-pop for a full year now, relying on the `el-get` recipe. I went to see the code to see how to add some feature when I discover this repo, and realize el-get  was pointing to the long outdated emacswiki version.

Using the new version I had to totally rewrite my shell-pop config. Updating el-get recipe would have so break a lot of user config. 
To prevent this, I reintroduce the config function in the legacy emacs wiki, keeping the same API, but changing their code to work with current version.  Doing so I refactored the custom, to have the `shell-type` définition in a single place.