### PR TITLE
Fix byte-compilation warning

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -204,7 +204,7 @@ The input format is the same as that of `kbd'."
     (eshell-reset)))
 
 (defun shell-pop--cd-to-cwd-shell (cwd)
-  (end-of-buffer)
+  (goto-char (point-max))
   (comint-kill-input)
   (insert (concat "cd " (shell-quote-argument cwd)))
   (let ((comint-process-echoes t))


### PR DESCRIPTION
Sorry for introducing a warning in my previous PR. This change fixes the following warning:

```
Warning: `end-of-buffer' is for interactive use only; use `(goto-char
    (point-max))' instead.
```