### PR TITLE
Bury shell before pop-out

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -329,6 +329,7 @@ The input format is the same as that of `kbd'."
   (if (shell-pop--full-p)
       (jump-to-register :shell-pop)
     (when (and (not (one-window-p)) (not (= shell-pop-window-height 100)))
+      (bury-buffer)
       (delete-window)
       (select-window shell-pop-last-window))
     (when shell-pop-restore-window-configuration


### PR DESCRIPTION
This prevents it from being the target of `other-buffer`, thus preventing it
from being selected by default when calling `switch-buffer`. Since shell-pop
already offers a quick way to access the shell, you want it to get out of the
way of regular methods.