### PR TITLE
Process exit hook and buffer cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ After saving the customized values, your .emacs file will be like as follows.
  '(shell-pop-universal-key "C-t")
  '(shell-pop-window-size 30)
  '(shell-pop-full-span t)
- '(shell-pop-window-position "bottom"))
+ '(shell-pop-window-position "bottom")
+ '(shell-pop-autocd-to-working-dir t)
+ '(shell-pop-restore-window-configuration t)
+ '(shell-pop-cleanup-buffer-at-process-exit t))
  ```
 
 #### `shell-pop-window-position`(Default: "bottom")

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ This hook runs after shell buffer pop-up.
 
 This hook runs before shell buffer pop-out.
 
+#### `shell-pop-process-exit-hook`
+
+This hook runs when the shell's process exits.
+
 
 ## Usage
 

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -185,6 +185,11 @@ The input format is the same as that of `kbd'."
   :type 'hook
   :group 'shell-pop)
 
+(defcustom shell-pop-process-exit-hook nil
+  "Hook run when the shell's process exits."
+  :type 'hook
+  :group 'shell-pop)
+
 (defun shell-pop--shell-buffer-name (index)
   (if (string-match-p "*\\'" shell-pop-internal-mode-buffer)
       (replace-regexp-in-string
@@ -266,6 +271,7 @@ The input format is the same as that of `kbd'."
          process
          (lambda (_proc change)
            (when (string-match-p "\\(?:finished\\|exited\\)" change)
+             (run-hooks 'shell-pop-process-exit-hook)
              (if (one-window-p)
                  (switch-to-buffer shell-pop-last-buffer)
                (delete-window)))))))))

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -154,6 +154,9 @@ effect when `shell-pop-window-position' value is \"full\"."
   :type 'boolean
   :group 'shell-pop)
 
+(defcustom shell-pop-cleanup-buffer-at-process-exit t
+  "If non-nil, cleanup the shell's buffer after its process exits.")
+
 (defun shell-pop--set-universal-key (symbol value)
   (set-default symbol value)
   (when value (global-set-key (read-kbd-macro value) 'shell-pop))
@@ -272,6 +275,8 @@ The input format is the same as that of `kbd'."
          (lambda (_proc change)
            (when (string-match-p "\\(?:finished\\|exited\\)" change)
              (run-hooks 'shell-pop-process-exit-hook)
+             (when shell-pop-cleanup-buffer-at-process-exit
+               (kill-buffer))
              (if (one-window-p)
                  (switch-to-buffer shell-pop-last-buffer)
                (delete-window)))))))))


### PR DESCRIPTION
Hey there !

I was bothered by the remaining buffer after terminating a shell, for instance using `C-d` or `exit`, that I always have to kill manually.

Which made me look for a configuration variable, that didn't exist. Which made me look for a hook, that didn't exist. I tried to do it in a `process-sentinel`, but you can only attach one per process and `shell-pop` already adds its own.

So here it is, a configuration variable to cleanup the buffer after the shell process exits AND a hook because if I was looking for one, chances are that other people as well for some other purpose.