### PR TITLE
Guard against window not being live

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -338,7 +338,8 @@ The input format is the same as that of `kbd'."
     (when (and (not (one-window-p)) (not (= shell-pop-window-height 100)))
       (bury-buffer)
       (delete-window)
-      (select-window shell-pop-last-window))
+      (when (window-live-p shell-pop-last-window)
+        (select-window shell-pop-last-window)))
     (when shell-pop-restore-window-configuration
       (switch-to-buffer shell-pop-last-buffer))))
 


### PR DESCRIPTION
I have been seeing the following backtrace when I close the shell on emacs 26, windows 7.

Debugger entered--Lisp error: (wrong-type-argument window-live-p #<window 61>)
  select-window(#<window 61>)
  shell-pop-out()
  shell-pop(nil)
  funcall-interactively(shell-pop nil)
  call-interactively(shell-pop nil nil)
  command-execute(shell-pop)