### PR TITLE
Change the default action for "shell"

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -85,10 +85,9 @@
                             (<= x 100)
                             (<= 0 x)))))
   :group 'shell-pop)
-(defvaralias 'shell-pop-window-height 'shell-pop-window-size)
 
 (defcustom shell-pop-full-span nil
-  "If non-nil, the shell spans full width of a window"
+  "If non-nil, the shell spans full width of a window."
   :type 'boolean
   :group 'shell-pop)
 
@@ -151,7 +150,7 @@ buffer from which the `shell-pop' command was invoked."
   "If non-nil, restore the original window configuration when
 shell-pop is closed.
 
-shell-pop's window is deleted in any case. This variable has no
+shell-pop's window is deleted in any case.  This variable has no
 effect when `shell-pop-window-position' value is \"full\"."
   :type 'boolean
   :group 'shell-pop)
@@ -188,7 +187,7 @@ The input format is the same as that of `kbd'."
   :group 'shell-pop)
 
 (defcustom shell-pop-out-hook nil
-  "Hook run before buffer pop-out"
+  "Hook run before buffer pop-out."
   :type 'hook
   :group 'shell-pop)
 

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -65,9 +65,9 @@
   :group 'shell)
 
 ;; internal{
-(defvar shell-pop-internal-mode "shell")
-(defvar shell-pop-internal-mode-buffer "*shell*")
-(defvar shell-pop-internal-mode-func '(lambda () (shell)))
+(defvar shell-pop-internal-mode)
+(defvar shell-pop-internal-mode-buffer)
+(defvar shell-pop-internal-mode-func)
 (defvar shell-pop-last-buffer nil)
 (defvar shell-pop-last-window nil)
 (defvar shell-pop-last-shell-buffer-index 1)

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -75,6 +75,8 @@
 (defvar shell-pop-window-configuration nil)
 ;; internal}
 
+(defvaralias 'shell-pop-window-height 'shell-pop-window-size)
+
 (defcustom shell-pop-window-size 30
   "Percentage for shell-buffer window size."
   :type '(restricted-sexp

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -115,7 +115,7 @@
              shell-pop-universal-key)
     (define-key term-raw-map (read-kbd-macro shell-pop-universal-key) 'shell-pop)))
 
-(defcustom shell-pop-shell-type '("shell" "*shell*" (lambda () (shell)))
+(defcustom shell-pop-shell-type '("shell" "*shell*" (lambda (buf) (shell buf)))
   "Type of shell that is launched when first popping into a shell.
 
 The value is a list with these items:
@@ -125,7 +125,7 @@ The value is a list with these items:
   :type '(choice
           (list :tag "Custom" string string function)
           (const :tag "shell"
-                 ("shell" "*shell*" (lambda () (shell))))
+                 ("shell" "*shell*" (lambda (buf) (shell buf))))
           (const :tag "terminal"
                  ("terminal" "*terminal*" (lambda () (term shell-pop-term-shell))))
           (const :tag "ansi-term"
@@ -288,8 +288,14 @@ The input format is the same as that of `kbd'."
   (let ((bufname (shell-pop--shell-buffer-name index)))
     (if (get-buffer bufname)
         (switch-to-buffer bufname)
-      (funcall (eval shell-pop-internal-mode-func))
-      (rename-buffer bufname)
+      (cond
+       ((string= shell-pop-internal-mode "shell")
+        (get-buffer-create bufname)
+        (switch-to-buffer bufname)
+        (funcall (eval shell-pop-internal-mode-func) bufname))
+       (t
+        (funcall (eval shell-pop-internal-mode-func))
+        (rename-buffer bufname)))
       (shell-pop--set-exit-action))
     (setq shell-pop-last-shell-buffer-name bufname
           shell-pop-last-shell-buffer-index index)))


### PR DESCRIPTION
1. I notice that the default values of `shell-pop-internal-mode', `shell-pop-internal-mode-buffer' and `shell-pop-internal-mode-func' are override and no longer needed. So I want to delete them.
2.  Some of doc strings do not have appropriate periods and a space.  So I want to add them.
3. The default setting for "shell" is not work properly for the first time. Because the function shell create new window rather than other functions. Therefore I want to change the code that way.  I confirmed that this code works only in Emacs 27.2, which is my concern...