### PR TITLE
Use explicit-shell-file-name and $ESHELL as default shells

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -134,7 +134,9 @@ The value is a list with these items:
   :set 'shell-pop--set-shell-type
   :group 'shell-pop)
 
-(defcustom shell-pop-term-shell shell-file-name
+(defcustom shell-pop-term-shell (or explicit-shell-file-name
+                                    (getenv "ESHELL")
+                                    shell-file-name)
   "Shell used in `term' and `ansi-term'."
   :type 'string
   :group 'shell-pop)


### PR DESCRIPTION
`M-x term` and `M-x ansi-term` both check these two values before using `shell-file-name`.  The description of the variable suggests that `explicit-shell-file-name` should be used for user-requested shells, whereas `shell-file-name` may be used (if different) for automatically spawned shells for things like compilation.

Since `shell-pop` is more like a wrapper around `M-x term`, it seems appropriate to check these variables first, the same way the interactive form of `M-x term` does.