### PR TITLE
shell-pop-split-window: Fix bug

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -362,7 +362,7 @@ The input format is the same as that of `kbd'."
     (cond
      (shell-pop-full-span
       (split-window
-       (frame-root-window) ; window
+       (window-main-window) ; window
        (shell-pop--calculate-window-size) ; size
        (shell-pop--translate-position shell-pop-window-position))) ; side
      (t

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -9,7 +9,7 @@
 ;; Created:       2009-05-31 23:57:08
 ;; Keywords:      shell, terminal, tools
 ;; Compatibility: GNU 24.x
-;; Package-Requires: ((emacs "24.1") (cl-lib "0.5"))
+;; Package-Requires: ((emacs "26.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Split the frame's main window instead of the root window to avoid violating a main window invariant in window.el. See [Emacs bug 73627](https://lists.gnu.org/archive/html/bug-gnu-emacs/2024-10/msg00214.html) for details.

This bug was fixed on the master branch (for Emacs 31), however, to support Emacs < 31, we need to work around the problem here. This also fixes #63, as well as buggy interactions with window maximization in Spacemacs.