### PR TITLE
Safe window deletion, fix zombie buffers, and fix asynchronous window hijacking

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -1,12 +1,12 @@
-;;; shell-pop.el --- helps you to use shell easily on Emacs. Only one key action to work. -*- lexical-binding: t; -*-
+;;; shell-pop.el --- Easily toggle a shell window with a single keystroke -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2009-2017  Kazuo Yagi
+;; Copyright (C) 2009-2026  Kazuo Yagi and contributors
 
 ;; Author:        Kazuo YAGI <kazuo.yagi@gmail.com>
+;; Maintainer:    James Cherti <https://www.jamescherti.com/contact/>
 ;; Maintainer:    Kazuo YAGI <kazuo.yagi@gmail.com>
 ;; URL:           http://github.com/kyagi/shell-pop-el
 ;; Version:       0.64
-;; Created:       2009-05-31 23:57:08
 ;; Keywords:      shell, terminal, tools
 ;; Compatibility: GNU 24.x
 ;; Package-Requires: ((emacs "26.1"))
@@ -26,25 +26,24 @@
 
 ;;; Commentary:
 ;;
-;; This is a utility which helps you pop up and pop out shell buffer
-;; window easily.  Just do M-x shell-pop, and it is strongly recommended
-;; to assign one hot-key to this function.
+;; The shell-pop package provides on-demand access to a terminal through a
+;; single, configurable key binding.
 ;;
-;; I hope this is useful for you, and ENJOY YOUR HAPPY HACKING!
-
-;;; Configuration:
+;; The package supports multiple terminal implementations, including term,
+;; `eshell' and `ansi-term', and ensures your original window configuration is
+;; restored when the terminal is hidden.
 ;;
-;; Use M-x customize-variable RET `shell-pop-shell-type' RET to
-;; customize the shell to use.  Four pre-set options are: `shell',
-;; `terminal', `ansi-term', and `eshell'.  You can also set your
-;; custom shell if you use other configuration.
-
-;; For `terminal' and `ansi-term' options, you can set the underlying
-;; shell by customizing `shell-pop-term-shell'.  By default,
-;; `shell-file-name' is used.
+;; Configuration:
+;; --------------
+;; Use M-x customize-variable RET `shell-pop-shell-type' RET to customize the
+;; shell to use. Four pre-set options are: `shell', `terminal', `ansi-term', and
+;; `eshell'. You can also set your custom shell if you use other configuration.
 ;;
-;; Use M-x customize-group RET shell-pop RET to set further options
-;; such as hotkey, window height and position.
+;; For `terminal' and `ansi-term' options, you can set the underlying shell by
+;; customizing `shell-pop-term-shell'. By default, `shell-file-name' is used.
+;;
+;; Use M-x customize-group RET shell-pop RET to set further options such as
+;; hotkey, window height and position.
 
 ;;; Code:
 
@@ -59,20 +58,23 @@
 (declare-function eshell-process-interact "esh-proc")
 (declare-function term-check-proc "term")
 (declare-function term-send-raw-string "term")
+(declare-function comint-kill-input "comint")
+(declare-function comint-send-input "comint")
 
 (defgroup shell-pop ()
-  "Shell-pop"
+  "Shell-pop."
   :group 'shell)
 
 ;; internal{
 (defvar shell-pop-internal-mode "shell")
 (defvar shell-pop-internal-mode-buffer "*shell*")
-(defvar shell-pop-internal-mode-func '(lambda () (shell)))
+(defvar shell-pop-internal-mode-func (lambda () (shell)))
 (defvar shell-pop-last-shell-buffer-index 1)
 (defvar-local shell-pop--is-shell-buffer nil
-  "Non-nil if the current buffer is managed by shell-pop.")
+  "Non-nil if the current buffer is managed by `shell-pop'.")
 ;; internal}
 
+(defvaralias 'shell-pop-window-height 'shell-pop-window-size)
 (defcustom shell-pop-window-size 30
   "Percentage for shell-buffer window size."
   :type '(restricted-sexp
@@ -81,10 +83,9 @@
                             (<= x 100)
                             (<= 0 x)))))
   :group 'shell-pop)
-(defvaralias 'shell-pop-window-height 'shell-pop-window-size)
 
 (defcustom shell-pop-full-span nil
-  "If non-nil, the shell spans full width of a window"
+  "If non-nil, the shell spans full width of a window."
   :type 'boolean
   :group 'shell-pop)
 
@@ -104,6 +105,7 @@
   :group 'shell-pop)
 
 (defun shell-pop--set-shell-type (symbol value)
+  "Set the shell type for `shell-pop' using SYMBOL and VALUE."
   (set-default symbol value)
   (setq shell-pop-internal-mode (nth 0 value)
         shell-pop-internal-mode-buffer (nth 1 value)
@@ -137,7 +139,7 @@ The value is a list with these items:
   :set 'shell-pop--set-shell-type
   :group 'shell-pop)
 
-(defcustom shell-pop-term-shell (or explicit-shell-file-name
+(defcustom shell-pop-term-shell (or (bound-and-true-p explicit-shell-file-name)
                                     (getenv "ESHELL")
                                     shell-file-name)
   "Shell used in `term' and `ansi-term'."
@@ -145,14 +147,12 @@ The value is a list with these items:
   :group 'shell-pop)
 
 (defcustom shell-pop-autocd-to-working-dir t
-  "If non-nil, automatically `cd' to working directory of the
-buffer from which the `shell-pop' command was invoked."
+  "If non-nil, cd to working directory from which `shell-pop' was invoked."
   :type 'boolean
   :group 'shell-pop)
 
 (defcustom shell-pop-restore-window-configuration t
-  "If non-nil, restore the original window configuration when
-shell-pop is closed.
+  "If non-nil, restore the window configuration when `shell-pop' is closed.
 
 shell-pop's window is deleted in any case. This variable has no
 effect when `shell-pop-window-position' value is \"full\"."
@@ -165,6 +165,7 @@ effect when `shell-pop-window-position' value is \"full\"."
   :group 'shell-pop)
 
 (defun shell-pop--set-universal-key (symbol value)
+  "Set the universal key for `shell-pop' using SYMBOL and VALUE."
   (set-default symbol value)
   (when value (global-set-key (read-kbd-macro value) 'shell-pop))
   (when (and (string= shell-pop-internal-mode "ansi-term")
@@ -192,7 +193,7 @@ The input format is the same as that of `kbd'."
   :group 'shell-pop)
 
 (defcustom shell-pop-out-hook nil
-  "Hook run before buffer pop-out"
+  "Hook run before buffer pop-out."
   :type 'hook
   :group 'shell-pop)
 
@@ -202,12 +203,14 @@ The input format is the same as that of `kbd'."
   :group 'shell-pop)
 
 (defun shell-pop--shell-buffer-name (index)
+  "Return the shell buffer name for the given INDEX."
   (if (string-match-p "*\\'" shell-pop-internal-mode-buffer)
       (replace-regexp-in-string
        "*\\'" (format "-%d*" index) shell-pop-internal-mode-buffer)
     (format "%s-%d" shell-pop-internal-mode-buffer index)))
 
 (defun shell-pop-check-internal-mode-buffer (index)
+  "Check and return the internal mode buffer for the given INDEX if it exists."
   (let ((bufname (shell-pop--shell-buffer-name index)))
     (when (get-buffer bufname)
       (if (or (and (fboundp 'term-check-proc)
@@ -219,17 +222,20 @@ The input format is the same as that of `kbd'."
     bufname))
 
 (defun shell-pop-get-internal-mode-buffer-window (index)
+  "Get the window containing the internal mode buffer for the given INDEX."
   (get-buffer-window (shell-pop-check-internal-mode-buffer index)))
 
 ;;;###autoload
 (defun shell-pop (arg)
+  "Toggle the shell buffer pop-up.
+With prefix ARG, switch to or create a specific shell buffer index."
   (interactive "P")
   (let* ((index (or arg shell-pop-last-shell-buffer-index))
          ;; Safely check for an existing window only if index is an integer. A
          ;; raw prefix arg like '(4) will bypass this and let shell-pop-up
          ;; handle it.
          (window (and (integerp index)
-                 (shell-pop-get-internal-mode-buffer-window index))))
+                      (shell-pop-get-internal-mode-buffer-window index))))
     ;; Scenario A: The user is already INSIDE a shell window
     (if (or shell-pop--is-shell-buffer
             (window-parameter nil 'shell-pop-is-window))
@@ -255,25 +261,30 @@ The input format is the same as that of `kbd'."
         (shell-pop-up index)))))
 
 (defun shell-pop--cd-to-cwd-eshell (cwd)
+  "Change the current working directory to CWD in eshell."
   (if (eshell-process-interact 'process-live-p)
       (message "Won't change CWD because of running process.")
     (setq default-directory cwd)
     (eshell-reset)))
 
 (defun shell-pop--cd-to-cwd-shell (cwd)
+  "Change the current working directory to CWD in shell."
   (goto-char (point-max))
   (comint-kill-input)
   (insert (concat "cd " (shell-quote-argument cwd)))
   (let ((comint-process-echoes t))
+    (ignore comint-process-echoes)
     (comint-send-input))
   (recenter 0))
 
 (defun shell-pop--cd-to-cwd-term (cwd)
+  "Change the current working directory to CWD in term."
   (when (fboundp 'term-send-raw-string)
     (term-send-raw-string (concat "cd " (shell-quote-argument cwd) "\n"))
     (term-send-raw-string "\C-l")))
 
 (defun shell-pop--cd-to-cwd (cwd)
+  "Change the current working directory of the shell buffer to CWD."
   (let ((abspath (expand-file-name cwd)))
     (cond ((string= shell-pop-internal-mode "eshell")
            (shell-pop--cd-to-cwd-eshell abspath))
@@ -283,13 +294,16 @@ The input format is the same as that of `kbd'."
            (shell-pop--cd-to-cwd-term abspath)))))
 
 (defsubst shell-pop--full-p ()
+  "Return non-nil if the shell window should span fully."
   (or (string= shell-pop-window-position "full")
       (>= shell-pop-window-height 100)))
 
 (defsubst shell-pop--split-side-p ()
+  "Return non-nil if the shell window should be split on the side."
   (member shell-pop-window-position '("left" "right")))
 
 (defun shell-pop--calculate-window-size ()
+  "Calculate and return the correct window size for the split."
   (let* ((win (and shell-pop-full-span (frame-root-window)))
          (size (if (shell-pop--split-side-p)
                    (window-width)
@@ -297,6 +311,7 @@ The input format is the same as that of `kbd'."
     (round (* size (/ (- 100 shell-pop-window-height) 100.0)))))
 
 (defun shell-pop--kill-and-delete-window ()
+  "Kill the current shell buffer and safely delete its window."
   ;; Unified Eshell cleanup to mirror process-sentinel behavior exactly.
   (let* ((buf (current-buffer))
          (win (get-buffer-window buf))
@@ -320,6 +335,7 @@ The input format is the same as that of `kbd'."
              (get-buffer-create "*scratch*"))))))))
 
 (defun shell-pop--set-exit-action ()
+  "Set the action to perform when the shell process exits."
   (if (string= shell-pop-internal-mode "eshell")
       (add-hook 'eshell-exit-hook 'shell-pop--kill-and-delete-window nil t)
     (let ((process (get-buffer-process (current-buffer))))
@@ -362,6 +378,7 @@ The input format is the same as that of `kbd'."
                         (get-buffer-create "*scratch*"))))))))))))))
 
 (defun shell-pop--switch-to-shell-buffer (index)
+  "Switch to or create the shell buffer for the given INDEX."
   (let ((bufname (shell-pop--shell-buffer-name index)))
     (if (get-buffer bufname)
         (switch-to-buffer bufname)
@@ -372,6 +389,7 @@ The input format is the same as that of `kbd'."
     (setq shell-pop-last-shell-buffer-index index)))
 
 (defun shell-pop--translate-position (pos)
+  "Translate POS to an Emacs window side symbol."
   (cond
    ((string= pos "top") 'above)
    ((string= pos "bottom") 'below)
@@ -379,6 +397,7 @@ The input format is the same as that of `kbd'."
    ((string= pos "right") 'right)))
 
 (defun shell-pop-get-unused-internal-mode-buffer-window ()
+  "Find an unused shell buffer window and return a cons cell of (index . window)."
   (let ((finish nil)
         (index 1)
         bufname)
@@ -390,6 +409,7 @@ The input format is the same as that of `kbd'."
     (cons index (get-buffer-window bufname))))
 
 (defun shell-pop-up (index)
+  "Pop up the shell buffer designated by INDEX."
   (run-hooks 'shell-pop-in-hook)
   (let* ((w (if (listp index)
                 (let ((ret (shell-pop-get-unused-internal-mode-buffer-window)))
@@ -441,6 +461,7 @@ The input format is the same as that of `kbd'."
     (run-hooks 'shell-pop-in-after-hook)))
 
 (defun shell-pop-out ()
+  "Hide the shell pop-up buffer and restore the previous layout."
   (run-hooks 'shell-pop-out-hook)
   (let* ((win (selected-window))
          (last-win (window-parameter win 'shell-pop-last-window))
@@ -471,6 +492,7 @@ The input format is the same as that of `kbd'."
           (set-window-buffer (selected-window) last-buf))))))
 
 (defun shell-pop-split-window ()
+  "Split the window for popping the shell buffer."
   (unless (shell-pop--full-p)
     (cond
      (shell-pop-full-span

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -265,11 +265,27 @@ The input format is the same as that of `kbd'."
     (round (* size (/ (- 100 shell-pop-window-height) 100.0)))))
 
 (defun shell-pop--kill-and-delete-window ()
-  ;; Explicitly target the buffer's window to prevent deleting the user's active
-  ;; window if shell exits in the background.
-  (let ((win (get-buffer-window (current-buffer))))
-    (when (and (window-live-p win) (eq (window-deletable-p win) t))
-      (delete-window win))))
+  ;; Unified Eshell cleanup to mirror process-sentinel behavior exactly.
+  (let* ((buf (current-buffer))
+         (win (get-buffer-window buf))
+         (target-buf (when (window-live-p win)
+                       (window-parameter win 'shell-pop-last-buffer))))
+
+    (when (and shell-pop-cleanup-buffer-at-process-exit
+               (buffer-live-p buf))
+      (kill-buffer buf))
+
+    (when (window-live-p win)
+      (set-window-parameter win 'shell-pop-is-window nil)
+      (if (eq (window-deletable-p win) t)
+          (delete-window win)
+        (set-window-buffer
+         win
+         (if (and target-buf (buffer-live-p target-buf))
+             target-buf
+           (if (fboundp 'get-scratch-buffer-create)
+               (get-scratch-buffer-create)
+             (get-buffer-create "*scratch*"))))))))
 
 (defun shell-pop--set-exit-action ()
   (if (string= shell-pop-internal-mode "eshell")
@@ -299,7 +315,8 @@ The input format is the same as that of `kbd'."
 
                ;; Only manipulate the window if it was visible on THIS frame
                (when (window-live-p proc-win)
-                 ;; FIX: Clear identity to prevent "zombie" toggles if window survives
+                 ;; Clear identity to prevent "zombie" toggles if window
+                 ;; survives
                  (set-window-parameter proc-win 'shell-pop-is-window nil)
                  (if (eq (window-deletable-p proc-win) t)
                      (delete-window proc-win)
@@ -347,24 +364,34 @@ The input format is the same as that of `kbd'."
                   (setq index (car ret))
                   (cdr ret))
               (shell-pop-get-internal-mode-buffer-window index)))
-         (cwd (replace-regexp-in-string "\\\\" "/" default-directory))
+         (cwd (when default-directory
+                (replace-regexp-in-string "\\\\" "/" default-directory)))
          (last-buf (current-buffer))
          (last-win (selected-window))
          ;; Only save full config in full mode so we don't accidentally revert
          ;; independent frame layout changes when closing a standard split
          (win-conf (when (shell-pop--full-p)
                      (list (current-window-configuration) (point-marker)))))
-
-    (when (shell-pop--full-p)
-      (delete-other-windows))
-
+    ;; Navigate to the target window BEFORE deleting other windows
+    ;; to prevent a crash if the target window is unselected in 'full' mode.
     (if w
         (select-window w)
       (unless (shell-pop--full-p)
         (let ((new-window (shell-pop-split-window)))
-          (select-window new-window)))
-      (when (and shell-pop-default-directory (file-directory-p shell-pop-default-directory))
-        (cd shell-pop-default-directory))
+          (select-window new-window))))
+
+    (when (shell-pop--full-p)
+      (delete-other-windows))
+
+    ;; Dynamically bind default-directory instead of using cd. This prevents
+    ;; "buffer poisoning" where the user's active code buffer gets its working
+    ;; directory overwritten.
+    (let ((default-directory
+           (if (and shell-pop-default-directory
+                    (file-directory-p shell-pop-default-directory))
+               (file-name-as-directory (expand-file-name
+                                        shell-pop-default-directory))
+             default-directory)))
       (shell-pop--switch-to-shell-buffer index))
 
     (set-window-parameter nil 'shell-pop-is-window t)
@@ -373,7 +400,10 @@ The input format is the same as that of `kbd'."
     (when (shell-pop--full-p)
       (set-window-parameter nil 'shell-pop-window-config win-conf))
 
+    ;; Safely check string equality only if both directories exist
     (when (and shell-pop-autocd-to-working-dir
+               cwd
+               default-directory
                (not (string= cwd default-directory)))
       (shell-pop--cd-to-cwd cwd))
     (run-hooks 'shell-pop-in-after-hook)))

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -224,12 +224,35 @@ The input format is the same as that of `kbd'."
 ;;;###autoload
 (defun shell-pop (arg)
   (interactive "P")
-  (if (or shell-pop--is-shell-buffer
-          (window-parameter nil 'shell-pop-is-window))
-      (if (null arg)
-          (shell-pop-out)
-        (shell-pop--switch-to-shell-buffer (prefix-numeric-value arg)))
-    (shell-pop-up (or arg shell-pop-last-shell-buffer-index))))
+  (let* ((index (or arg shell-pop-last-shell-buffer-index))
+         ;; Safely check for an existing window only if index is an integer. A
+         ;; raw prefix arg like '(4) will bypass this and let shell-pop-up
+         ;; handle it.
+         (window (and (integerp index)
+                 (shell-pop-get-internal-mode-buffer-window index))))
+    ;; Scenario A: The user is already INSIDE a shell window
+    (if (or shell-pop--is-shell-buffer
+            (window-parameter nil 'shell-pop-is-window))
+        ;; No prefix (null arg): The user pressed a hotkey. It runs
+        ;; `shell-pop-out' to close the shell.
+        (if (null arg)
+            (shell-pop-out)
+          ;; If a prefix arg is provided while inside the shell: A raw C-u '(4)
+          ;; should find a new unused index dynamically. Otherwise, use the
+          ;; exact numeric prefix (e.g., M-2 -> 2).
+          (let ((target-index
+                 (if (listp arg)
+                     (car (shell-pop-get-unused-internal-mode-buffer-window))
+                   (prefix-numeric-value arg))))
+            (shell-pop--switch-to-shell-buffer target-index)))
+      ;; Scenario B: The user is OUTSIDE the shell (e.g., in a code buffer)
+      (if (and window (null arg))
+          ;; The shell window (window) is visible somewhere else, and the user
+          ;; didn't pass a prefix, to that shell window and close it.
+          (progn
+            (select-window window)
+            (shell-pop-out))
+        (shell-pop-up index)))))
 
 (defun shell-pop--cd-to-cwd-eshell (cwd)
   (if (eshell-process-interact 'process-live-p)

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -266,7 +266,7 @@ The input format is the same as that of `kbd'."
     (round (* size (/ (- 100 shell-pop-window-height) 100.0)))))
 
 (defun shell-pop--kill-and-delete-window ()
-  (unless (one-window-p)
+  (when (window-deletable-p)
     (delete-window)))
 
 (defun shell-pop--set-exit-action ()
@@ -276,14 +276,33 @@ The input format is the same as that of `kbd'."
       (when process
         (set-process-sentinel
          process
-         (lambda (_proc change)
+         (lambda (proc change)
            (when (string-match-p "\\(?:finished\\|exited\\)" change)
              (run-hooks 'shell-pop-process-exit-hook)
-             (when shell-pop-cleanup-buffer-at-process-exit
-               (kill-buffer))
-             (if (one-window-p)
-                 (switch-to-buffer shell-pop-last-buffer)
-               (delete-window)))))))))
+
+             (let* ((proc-buf (process-buffer proc))
+                    ;; Safely get the window ONLY on the current frame
+                    (proc-win (when (buffer-live-p proc-buf)
+                                (get-buffer-window proc-buf))))
+               ;; Kill the buffer if requested
+               (when (and shell-pop-cleanup-buffer-at-process-exit
+                          (buffer-live-p proc-buf))
+                 (kill-buffer proc-buf))
+
+               ;; Only manipulate the window if it was visible on THIS frame
+               (when (window-live-p proc-win)
+                 (if (window-deletable-p proc-win)
+                     ;; Undo the shell-pop split
+                     (delete-window proc-win)
+                   ;; If it's the last window, safely swap the buffer
+                   (set-window-buffer
+                    proc-win
+                    (let ((target-buf (get-buffer shell-pop-last-buffer)))
+                      (if target-buf
+                          target-buf
+                        (if (fboundp 'get-scratch-buffer-create)
+                            (get-scratch-buffer-create)
+                          (get-buffer-create "*scratch*")))))))))))))))
 
 (defun shell-pop--switch-to-shell-buffer (index)
   (let ((bufname (shell-pop--shell-buffer-name index)))
@@ -327,8 +346,8 @@ The input format is the same as that of `kbd'."
       (delete-other-windows))
     (if w
         (select-window w)
-      ;; save shell-pop-last-buffer and shell-pop-last-window to return
-      (setq shell-pop-last-buffer (buffer-name)
+      ;; save shell-pop-last-buffer as buffer object and `shell-pop-last-window'
+      (setq shell-pop-last-buffer (current-buffer)
             shell-pop-last-window (selected-window))
       (when (and (not (= shell-pop-window-height 100))
                  (not (shell-pop--full-p)))
@@ -350,12 +369,15 @@ The input format is the same as that of `kbd'."
         (set-window-configuration window-conf)
         (when (marker-buffer marker)
           (goto-char marker)))
-    (when (and (not (one-window-p)) (not (= shell-pop-window-height 100)))
+    (when (and (window-deletable-p) (not (= shell-pop-window-height 100)))
       (bury-buffer)
       (delete-window)
-      (select-window shell-pop-last-window))
+      (when (window-live-p shell-pop-last-window)
+        (select-window shell-pop-last-window)))
     (when shell-pop-restore-window-configuration
-      (switch-to-buffer shell-pop-last-buffer))))
+      (let ((buffer (get-buffer shell-pop-last-buffer)))
+        (when buffer
+          (switch-to-buffer buffer))))))
 
 (defun shell-pop-split-window ()
   (unless (shell-pop--full-p)

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -251,7 +251,8 @@ The input format is the same as that of `kbd'."
            (shell-pop--cd-to-cwd-term abspath)))))
 
 (defsubst shell-pop--full-p ()
-  (string= shell-pop-window-position "full"))
+  (or (string= shell-pop-window-position "full")
+      (>= shell-pop-window-height 100)))
 
 (defsubst shell-pop--split-side-p ()
   (member shell-pop-window-position '("left" "right")))
@@ -264,8 +265,11 @@ The input format is the same as that of `kbd'."
     (round (* size (/ (- 100 shell-pop-window-height) 100.0)))))
 
 (defun shell-pop--kill-and-delete-window ()
-  (when (eq (window-deletable-p) t) ; t to ignore 'frame and 'tab
-    (delete-window)))
+  ;; Explicitly target the buffer's window to prevent deleting the user's active
+  ;; window if shell exits in the background.
+  (let ((win (get-buffer-window (current-buffer))))
+    (when (and (window-live-p win) (eq (window-deletable-p win) t))
+      (delete-window win))))
 
 (defun shell-pop--set-exit-action ()
   (if (string= shell-pop-internal-mode "eshell")
@@ -295,8 +299,9 @@ The input format is the same as that of `kbd'."
 
                ;; Only manipulate the window if it was visible on THIS frame
                (when (window-live-p proc-win)
-                 (if (eq (window-deletable-p proc-win) t) ; Ignore frame/tab
-                     ;; Undo the shell-pop split
+                 ;; FIX: Clear identity to prevent "zombie" toggles if window survives
+                 (set-window-parameter proc-win 'shell-pop-is-window nil)
+                 (if (eq (window-deletable-p proc-win) t)
                      (delete-window proc-win)
                    ;; If it's the last window, safely swap the buffer
                    (set-window-buffer
@@ -319,10 +324,10 @@ The input format is the same as that of `kbd'."
 
 (defun shell-pop--translate-position (pos)
   (cond
-    ((string= pos "top") 'above)
-    ((string= pos "bottom") 'below)
-    ((string= pos "left") 'left)
-    ((string= pos "right") 'right)))
+   ((string= pos "top") 'above)
+   ((string= pos "bottom") 'below)
+   ((string= pos "left") 'left)
+   ((string= pos "right") 'right)))
 
 (defun shell-pop-get-unused-internal-mode-buffer-window ()
   (let ((finish nil)
@@ -345,14 +350,17 @@ The input format is the same as that of `kbd'."
          (cwd (replace-regexp-in-string "\\\\" "/" default-directory))
          (last-buf (current-buffer))
          (last-win (selected-window))
+         ;; Only save full config in full mode so we don't accidentally revert
+         ;; independent frame layout changes when closing a standard split
          (win-conf (when (shell-pop--full-p)
                      (list (current-window-configuration) (point-marker)))))
+
     (when (shell-pop--full-p)
       (delete-other-windows))
+
     (if w
         (select-window w)
-      (when (and (not (= shell-pop-window-height 100))
-                 (not (shell-pop--full-p)))
+      (unless (shell-pop--full-p)
         (let ((new-window (shell-pop-split-window)))
           (select-window new-window)))
       (when (and shell-pop-default-directory (file-directory-p shell-pop-default-directory))
@@ -376,26 +384,29 @@ The input format is the same as that of `kbd'."
          (last-win (window-parameter win 'shell-pop-last-window))
          (last-buf (window-parameter win 'shell-pop-last-buffer))
          (win-conf (window-parameter win 'shell-pop-window-config)))
-    (if (shell-pop--full-p)
-        (when win-conf
+    ;; Strip the identity so the window doesn't trap toggles if it survives
+    (set-window-parameter win 'shell-pop-is-window nil)
+
+    (if (and (shell-pop--full-p)
+             win-conf
+             (window-configuration-p (car win-conf)))
+        (progn
           (set-window-configuration (car win-conf))
           (when (marker-buffer (cadr win-conf))
             (goto-char (cadr win-conf))))
+      ;; For non-full splits: Always bury the shell buffer out of sight
+      (bury-buffer)
 
-      ;; Always get the shell buffer out of the way when not in 100% height
-      (when (not (= shell-pop-window-height 100))
-        (bury-buffer)
+      (when (eq (window-deletable-p win) t)
+        (delete-window win)
+        (when (window-live-p last-win)
+          (select-window last-win)))
 
-        ;; Only attempt to delete the window if it's strictly safe
-        (when (eq (window-deletable-p win) t)
-          (delete-window win)
-          (when (window-live-p last-win)
-            (select-window last-win))))
-
-      ;; Restore the originating buffer if configured
+      ;; The variable is named "restore-window-configuration", but its
+      ;; intended behavior is actually to just restore the originating buffer.
       (when shell-pop-restore-window-configuration
         (when (and last-buf (buffer-live-p last-buf))
-          (switch-to-buffer last-buf))))))
+          (set-window-buffer (selected-window) last-buf))))))
 
 (defun shell-pop-split-window ()
   (unless (shell-pop--full-p)

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -51,13 +51,14 @@
 (eval-when-compile
   (defvar shell-pop-universal-key)
   (defvar eshell-last-input-start)
-  (defvar eshell-last-input-end))
+  (defvar eshell-last-input-end)
+  (defvar term-raw-map)) ; Mute compiler warning for optional variable
 
 (declare-function eshell-send-input "esh-mode")
 (declare-function eshell-reset "esh-mode")
 (declare-function eshell-process-interact "esh-proc")
-
-(require 'term)
+(declare-function term-check-proc "term")
+(declare-function term-send-raw-string "term")
 
 (defgroup shell-pop ()
   "Shell-pop"
@@ -108,7 +109,8 @@
         shell-pop-internal-mode-buffer (nth 1 value)
         shell-pop-internal-mode-func (nth 2 value))
   (when (and (string= shell-pop-internal-mode "ansi-term")
-             shell-pop-universal-key)
+             shell-pop-universal-key
+             (boundp 'term-raw-map))
     (define-key term-raw-map (read-kbd-macro shell-pop-universal-key) 'shell-pop)))
 
 (defcustom shell-pop-shell-type '("shell" "*shell*" (lambda () (shell)))
@@ -123,9 +125,13 @@ The value is a list with these items:
           (const :tag "shell"
                  ("shell" "*shell*" (lambda () (shell))))
           (const :tag "terminal"
-                 ("terminal" "*terminal*" (lambda () (term shell-pop-term-shell))))
+                 ("terminal" "*terminal*" (lambda ()
+                                            (when (fboundp 'term)
+                                              (term shell-pop-term-shell)))))
           (const :tag "ansi-term"
-                 ("ansi-term" "*ansi-term*" (lambda () (ansi-term shell-pop-term-shell))))
+                 ("ansi-term" "*ansi-term*" (lambda ()
+                                              (when (fboundp 'ansi-term)
+                                                (ansi-term shell-pop-term-shell)))))
           (const :tag "eshell"
                  ("eshell" "*eshell*" (lambda () (eshell)))))
   :set 'shell-pop--set-shell-type
@@ -162,7 +168,8 @@ effect when `shell-pop-window-position' value is \"full\"."
   (set-default symbol value)
   (when value (global-set-key (read-kbd-macro value) 'shell-pop))
   (when (and (string= shell-pop-internal-mode "ansi-term")
-             shell-pop-universal-key)
+             shell-pop-universal-key
+             (boundp 'term-raw-map))
     (define-key term-raw-map (read-kbd-macro value) 'shell-pop)))
 
 ;;;###autoload
@@ -203,7 +210,8 @@ The input format is the same as that of `kbd'."
 (defun shell-pop-check-internal-mode-buffer (index)
   (let ((bufname (shell-pop--shell-buffer-name index)))
     (when (get-buffer bufname)
-      (if (or (term-check-proc bufname)
+      (if (or (and (fboundp 'term-check-proc)
+                   (term-check-proc bufname))
               (string= shell-pop-internal-mode "eshell"))
           bufname
         (kill-buffer bufname)
@@ -238,8 +246,9 @@ The input format is the same as that of `kbd'."
   (recenter 0))
 
 (defun shell-pop--cd-to-cwd-term (cwd)
-  (term-send-raw-string (concat "cd " (shell-quote-argument cwd) "\n"))
-  (term-send-raw-string "\C-l"))
+  (when (fboundp 'term-send-raw-string)
+    (term-send-raw-string (concat "cd " (shell-quote-argument cwd) "\n"))
+    (term-send-raw-string "\C-l")))
 
 (defun shell-pop--cd-to-cwd (cwd)
   (let ((abspath (expand-file-name cwd)))

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -58,7 +58,6 @@
 (declare-function eshell-process-interact "esh-proc")
 
 (require 'term)
-(require 'cl-lib)
 
 (defgroup shell-pop ()
   "Shell-pop"
@@ -68,11 +67,9 @@
 (defvar shell-pop-internal-mode "shell")
 (defvar shell-pop-internal-mode-buffer "*shell*")
 (defvar shell-pop-internal-mode-func '(lambda () (shell)))
-(defvar shell-pop-last-buffer nil)
-(defvar shell-pop-last-window nil)
 (defvar shell-pop-last-shell-buffer-index 1)
-(defvar shell-pop-last-shell-buffer-name "")
-(defvar shell-pop-window-configuration nil)
+(defvar-local shell-pop--is-shell-buffer nil
+  "Non-nil if the current buffer is managed by shell-pop.")
 ;; internal}
 
 (defcustom shell-pop-window-size 30
@@ -219,7 +216,8 @@ The input format is the same as that of `kbd'."
 ;;;###autoload
 (defun shell-pop (arg)
   (interactive "P")
-  (if (string= (buffer-name) shell-pop-last-shell-buffer-name)
+  (if (or shell-pop--is-shell-buffer
+          (window-parameter nil 'shell-pop-is-window))
       (if (null arg)
           (shell-pop-out)
         (shell-pop--switch-to-shell-buffer (prefix-numeric-value arg)))
@@ -266,7 +264,7 @@ The input format is the same as that of `kbd'."
     (round (* size (/ (- 100 shell-pop-window-height) 100.0)))))
 
 (defun shell-pop--kill-and-delete-window ()
-  (when (window-deletable-p)
+  (when (eq (window-deletable-p) t) ; t to ignore 'frame and 'tab
     (delete-window)))
 
 (defun shell-pop--set-exit-action ()
@@ -283,26 +281,31 @@ The input format is the same as that of `kbd'."
              (let* ((proc-buf (process-buffer proc))
                     ;; Safely get the window ONLY on the current frame
                     (proc-win (when (buffer-live-p proc-buf)
-                                (get-buffer-window proc-buf))))
-               ;; Kill the buffer if requested
+                                (get-buffer-window proc-buf)))
+                    ;; Safely grab the target buffer BEFORE we kill the process
+                    ;; buffer since killing it might cause Emacs to destroy
+                    ;; proc-win entirely.
+                    (target-buf (when (window-live-p proc-win)
+                                  (window-parameter proc-win
+                                                    'shell-pop-last-buffer))))
+
                (when (and shell-pop-cleanup-buffer-at-process-exit
                           (buffer-live-p proc-buf))
                  (kill-buffer proc-buf))
 
                ;; Only manipulate the window if it was visible on THIS frame
                (when (window-live-p proc-win)
-                 (if (window-deletable-p proc-win)
+                 (if (eq (window-deletable-p proc-win) t) ; Ignore frame/tab
                      ;; Undo the shell-pop split
                      (delete-window proc-win)
                    ;; If it's the last window, safely swap the buffer
                    (set-window-buffer
                     proc-win
-                    (let ((target-buf (get-buffer shell-pop-last-buffer)))
-                      (if target-buf
-                          target-buf
-                        (if (fboundp 'get-scratch-buffer-create)
-                            (get-scratch-buffer-create)
-                          (get-buffer-create "*scratch*")))))))))))))))
+                    (if (and target-buf (buffer-live-p target-buf))
+                        target-buf
+                      (if (fboundp 'get-scratch-buffer-create)
+                          (get-scratch-buffer-create)
+                        (get-buffer-create "*scratch*"))))))))))))))
 
 (defun shell-pop--switch-to-shell-buffer (index)
   (let ((bufname (shell-pop--shell-buffer-name index)))
@@ -311,8 +314,8 @@ The input format is the same as that of `kbd'."
       (funcall (eval shell-pop-internal-mode-func))
       (rename-buffer bufname)
       (shell-pop--set-exit-action))
-    (setq shell-pop-last-shell-buffer-name bufname
-          shell-pop-last-shell-buffer-index index)))
+    (setq shell-pop--is-shell-buffer t)
+    (setq shell-pop-last-shell-buffer-index index)))
 
 (defun shell-pop--translate-position (pos)
   (cond
@@ -334,21 +337,20 @@ The input format is the same as that of `kbd'."
 
 (defun shell-pop-up (index)
   (run-hooks 'shell-pop-in-hook)
-  (let ((w (if (listp index)
-               (let ((ret (shell-pop-get-unused-internal-mode-buffer-window)))
-                 (setq index (car ret))
-                 (cdr ret))
-             (shell-pop-get-internal-mode-buffer-window index)))
-        (cwd (replace-regexp-in-string "\\\\" "/" default-directory)))
+  (let* ((w (if (listp index)
+                (let ((ret (shell-pop-get-unused-internal-mode-buffer-window)))
+                  (setq index (car ret))
+                  (cdr ret))
+              (shell-pop-get-internal-mode-buffer-window index)))
+         (cwd (replace-regexp-in-string "\\\\" "/" default-directory))
+         (last-buf (current-buffer))
+         (last-win (selected-window))
+         (win-conf (when (shell-pop--full-p)
+                     (list (current-window-configuration) (point-marker)))))
     (when (shell-pop--full-p)
-      (setq shell-pop-window-configuration
-            (list (current-window-configuration) (point-marker)))
       (delete-other-windows))
     (if w
         (select-window w)
-      ;; save shell-pop-last-buffer as buffer object and `shell-pop-last-window'
-      (setq shell-pop-last-buffer (current-buffer)
-            shell-pop-last-window (selected-window))
       (when (and (not (= shell-pop-window-height 100))
                  (not (shell-pop--full-p)))
         (let ((new-window (shell-pop-split-window)))
@@ -356,6 +358,13 @@ The input format is the same as that of `kbd'."
       (when (and shell-pop-default-directory (file-directory-p shell-pop-default-directory))
         (cd shell-pop-default-directory))
       (shell-pop--switch-to-shell-buffer index))
+
+    (set-window-parameter nil 'shell-pop-is-window t)
+    (set-window-parameter nil 'shell-pop-last-window last-win)
+    (set-window-parameter nil 'shell-pop-last-buffer last-buf)
+    (when (shell-pop--full-p)
+      (set-window-parameter nil 'shell-pop-window-config win-conf))
+
     (when (and shell-pop-autocd-to-working-dir
                (not (string= cwd default-directory)))
       (shell-pop--cd-to-cwd cwd))
@@ -363,21 +372,30 @@ The input format is the same as that of `kbd'."
 
 (defun shell-pop-out ()
   (run-hooks 'shell-pop-out-hook)
-  (if (shell-pop--full-p)
-      (let ((window-conf (cl-first shell-pop-window-configuration))
-            (marker (cl-second shell-pop-window-configuration)))
-        (set-window-configuration window-conf)
-        (when (marker-buffer marker)
-          (goto-char marker)))
-    (when (and (window-deletable-p) (not (= shell-pop-window-height 100)))
-      (bury-buffer)
-      (delete-window)
-      (when (window-live-p shell-pop-last-window)
-        (select-window shell-pop-last-window)))
-    (when shell-pop-restore-window-configuration
-      (let ((buffer (get-buffer shell-pop-last-buffer)))
-        (when buffer
-          (switch-to-buffer buffer))))))
+  (let* ((win (selected-window))
+         (last-win (window-parameter win 'shell-pop-last-window))
+         (last-buf (window-parameter win 'shell-pop-last-buffer))
+         (win-conf (window-parameter win 'shell-pop-window-config)))
+    (if (shell-pop--full-p)
+        (when win-conf
+          (set-window-configuration (car win-conf))
+          (when (marker-buffer (cadr win-conf))
+            (goto-char (cadr win-conf))))
+
+      ;; Always get the shell buffer out of the way when not in 100% height
+      (when (not (= shell-pop-window-height 100))
+        (bury-buffer)
+
+        ;; Only attempt to delete the window if it's strictly safe
+        (when (eq (window-deletable-p win) t)
+          (delete-window win)
+          (when (window-live-p last-win)
+            (select-window last-win))))
+
+      ;; Restore the originating buffer if configured
+      (when shell-pop-restore-window-configuration
+        (when (and last-buf (buffer-live-p last-buf))
+          (switch-to-buffer last-buf))))))
 
 (defun shell-pop-split-window ()
   (unless (shell-pop--full-p)


### PR DESCRIPTION
Hello @kyagi,

This pull request fixes the following bugs shell-pop's buffer tracking and window cleanup:

1. shell-pop tracks the user's previous buffer by storing its name as a string in shell-pop-last-buffer. If that buffer is dynamically renamed by a package like uniquify (e.g., from `file.el` to `file.el*dir-name` after a naming conflict is resolved), shell-pop fails to find it. Instead of failing gracefully, Emacs's switch-to-buffer silently creates a brand new, empty fundamental-mode buffer using the outdated string name.
2. The process sentinel in shell-pop--set-exit-action is unsafe. Process sentinels run asynchronously. If a user compiles a script in ansi-term, switches to a different window to write code, and the script finishes in the background, the sentinel fires and blindly calls (delete-window) and (kill-buffer). Because it does not explicitly target the shell's window, it executes against the user's /currently selected window/, hijacking and destroying their active workspace.
3. Handle dead window reference in shell-pop-out
4. Replace `one-window-p` with `window-deletable-p`. In a multi-frame or multi–tab-bar tab setup, `one-window-p` checks the currently selected frame. If the shell exits in a background frame that has only one window, but the cursor is in a different frame with multiple windows, `one-window-p` will return nil.
5. Remove the cl-lib dependency
6. Refactor shell-pop state to use window parameters. Previously, tracking the active shell buffer and window relied on global or buffer-local variables. This approach failed when using shell-pop across multiple frames or tab-bar tabs, as the shared global state would be overwritten, breaking the pop-out logic for previous instances. This change isolates the state by attaching it directly to the window object using Emacs window parameters.
7. Refactor shell-pop window management and layout restoration
8. Add missing docstrings, update header and fix all warnings
9. Fix global toggle

