### PR TITLE
Fixes #66: Fix Eshell history loss on exit

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -339,7 +339,7 @@ With prefix ARG, switch to or create a specific shell buffer index."
 (defun shell-pop--set-exit-action ()
   "Set the action to perform when the shell process exits."
   (if (string= shell-pop-internal-mode "eshell")
-      (add-hook 'eshell-exit-hook 'shell-pop--kill-and-delete-window nil t)
+      (add-hook 'eshell-exit-hook 'shell-pop--kill-and-delete-window t t)
     (let ((process (get-buffer-process (current-buffer))))
       (when process
         (set-process-sentinel


### PR DESCRIPTION
This fixes Eshell history loss on exit.

Previously, shell-pop added its cleanup function to the front of the hook list. Because this function calls `kill-buffer`, it destroyed the buffer before Eshell's native teardown routines (such as eshell-write-history) had a chance to execute.