### PR TITLE
Add support for vterm and eat terminal emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The **shell-pop** Emacs package provides on-demand access to a terminal through a single, configurable key binding.
 
-The package supports multiple terminal implementations, including `term`, `eshell` and `ansi-term`, and ensures your original window configuration is restored when the terminal is hidden.
+The package supports multiple terminal implementations, including `term`, `eshell`, `ansi-term`, `vterm`, and `eat`, and ensures your original window configuration is restored when the terminal is hidden.
 
 ## Installation
 
@@ -48,7 +48,7 @@ Make sure to place shell-pop.el somewhere in the load-path and add the following
 
 ### Configuring the terminal
 
-Here are the exact configurations for the four most popular built-in Emacs shells. Simply copy and paste your preferred option into your init file:
+Here are the exact configurations for the most popular Emacs shells. Simply copy and paste your preferred option into your init file:
 
 #### ansi-term
 *Note: This will use the shell defined in your `shell-file-name` variable (e.g., bash, zsh).*
@@ -65,6 +65,31 @@ Here are the exact configurations for the four most popular built-in Emacs shell
   (setopt shell-pop-shell-type '("terminal" "*terminal*"
                                  (lambda ()
                                    (term shell-pop-term-shell)))))
+```
+
+#### vterm
+
+*Note: Requires the `vterm` package to be installed.*
+
+```elisp
+(with-eval-after-load 'shell-pop
+  (setopt shell-pop-shell-type '("vterm" "*vterm*"
+                                 (lambda ()
+                                   (when (fboundp 'vterm)
+                                     (let ((vterm-shell shell-pop-term-shell))
+                                       (vterm)))))))
+```
+
+#### eat
+
+*Note: Requires the `eat` package to be installed.*
+
+```elisp
+(with-eval-after-load 'shell-pop
+  (setopt shell-pop-shell-type '("eat" "*eat*"
+                                 (lambda ()
+                                   (when (fboundp 'eat)
+                                     (eat shell-pop-term-shell))))))
 ```
 
 #### Shell
@@ -107,7 +132,7 @@ This option allows you to generate the shell window with the same width as the c
 
 ### M-x Customize
 
-Use `M-x customize-variable RET shell-pop-shell-type RET` to customize the shell to use. Four pre-set options are: `shell`, `terminal`, `ansi-term`, and `eshell`. You can also set your custom shell if you use other configuration.
+Use `M-x customize-variable RET shell-pop-shell-type RET` to customize the shell to use. Six pre-set options are: `shell`, `terminal`, `ansi-term`, `eshell`, `vterm`, and `eat`. You can also set your custom shell if you use other configuration.
 
 For the `terminal` and `ansi-term` options, you can set the underlying shell by customizing `shell-pop-term-shell`. By default, `shell-file-name` is used, but you can also specify paths like `/bin/tcsh`, `/bin/bash`, or `/bin/zsh`.
 
@@ -130,7 +155,7 @@ After saving the customized values, your init file will look similar to the foll
  '(shell-pop-autocd-to-working-dir t)
  '(shell-pop-restore-window-configuration t)
  '(shell-pop-cleanup-buffer-at-process-exit t))
- ```
+```
 
 ## Usage
 

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -30,14 +30,15 @@
 ;; single, configurable key binding.
 ;;
 ;; The package supports multiple terminal implementations, including term,
-;; `eshell' and `ansi-term', and ensures your original window configuration is
-;; restored when the terminal is hidden.
+;; `eshell', `ansi-term', `vterm', and `eat', and ensures your original window
+;; configuration is restored when the terminal is hidden.
 ;;
 ;; Configuration:
 ;; --------------
 ;; Use M-x customize-variable RET `shell-pop-shell-type' RET to customize the
-;; shell to use. Four pre-set options are: `shell', `terminal', `ansi-term', and
-;; `eshell'. You can also set your custom shell if you use other configuration.
+;; shell to use. Six pre-set options are: `shell', `terminal', `ansi-term',
+;; `eshell', `vterm', and `eat'. You can also set your custom shell if you use
+;; other configuration.
 ;;
 ;; For `terminal' and `ansi-term' options, you can set the underlying shell by
 ;; customizing `shell-pop-term-shell'. By default, `shell-file-name' is used.
@@ -51,7 +52,8 @@
   (defvar shell-pop-universal-key)
   (defvar eshell-last-input-start)
   (defvar eshell-last-input-end)
-  (defvar term-raw-map)) ; Mute compiler warning for optional variable
+  (defvar term-raw-map)
+  (defvar eat-terminal)) ; Mute compiler warning for optional variable
 
 (declare-function eshell-send-input "esh-mode")
 (declare-function eshell-reset "esh-mode")
@@ -60,6 +62,11 @@
 (declare-function term-send-raw-string "term")
 (declare-function comint-kill-input "comint")
 (declare-function comint-send-input "comint")
+(declare-function vterm "vterm")
+(declare-function vterm-send-string "vterm")
+(declare-function vterm-send-return "vterm")
+(declare-function eat "eat")
+(declare-function eat-term-send-string "eat")
 
 (defgroup shell-pop ()
   "Shell-pop."
@@ -127,15 +134,29 @@ The value is a list with these items:
           (const :tag "shell"
                  ("shell" "*shell*" (lambda () (shell))))
           (const :tag "terminal"
-                 ("terminal" "*terminal*" (lambda ()
-                                            (when (fboundp 'term)
-                                              (term shell-pop-term-shell)))))
+                 ("terminal" "*terminal*"
+                  (lambda ()
+                    (when (fboundp 'term)
+                      (term shell-pop-term-shell)))))
           (const :tag "ansi-term"
-                 ("ansi-term" "*ansi-term*" (lambda ()
-                                              (when (fboundp 'ansi-term)
-                                                (ansi-term shell-pop-term-shell)))))
+                 ("ansi-term" "*ansi-term*"
+                  (lambda ()
+                    (when (fboundp 'ansi-term)
+                      (ansi-term shell-pop-term-shell)))))
           (const :tag "eshell"
-                 ("eshell" "*eshell*" (lambda () (eshell)))))
+                 ("eshell" "*eshell*"
+                  (lambda () (eshell))))
+          (const :tag "vterm"
+                 ("vterm" "*vterm*"
+                  (lambda ()
+                    (when (fboundp 'vterm)
+                      (let ((vterm-shell shell-pop-term-shell))
+                        (vterm))))))
+          (const :tag "eat"
+                 ("eat" "*eat*"
+                  (lambda ()
+                    (when (fboundp 'eat)
+                      (eat shell-pop-term-shell))))))
   :set 'shell-pop--set-shell-type
   :group 'shell-pop)
 
@@ -215,7 +236,10 @@ The input format is the same as that of `kbd'."
     (when (get-buffer bufname)
       (if (or (and (fboundp 'term-check-proc)
                    (term-check-proc bufname))
-              (string= shell-pop-internal-mode "eshell"))
+              (string= shell-pop-internal-mode "eshell")
+              (and (member shell-pop-internal-mode '("vterm" "eat"))
+                   (let ((proc (get-buffer-process bufname)))
+                     (and proc (memq (process-status proc) '(run stop))))))
           bufname
         (kill-buffer bufname)
         nil))
@@ -285,6 +309,18 @@ With prefix ARG, switch to or create a specific shell buffer index."
     ;; Send the clear command and a Newline
     (term-send-raw-string "clear\n")))
 
+(defun shell-pop--cd-to-cwd-vterm (cwd)
+  "Change the terminal's directory to CWD and clear the screen in vterm."
+  (when (fboundp 'vterm-send-string)
+    (vterm-send-string (concat "cd " (shell-quote-argument cwd) "\nclear\n"))))
+
+(defun shell-pop--cd-to-cwd-eat (cwd)
+  "Change the terminal's directory to CWD and clear the screen in eat."
+  (let ((proc (get-buffer-process (current-buffer))))
+    (when (and proc (fboundp 'eat-term-send-string))
+      ;; Use the process object directly if eat-terminal isn't in scope
+      (process-send-string proc (concat "cd " (shell-quote-argument cwd) "\nclear\n")))))
+
 (defun shell-pop--cd-to-cwd (cwd)
   "Change the current working directory of the shell buffer to CWD."
   (let ((abspath (expand-file-name cwd)))
@@ -292,6 +328,10 @@ With prefix ARG, switch to or create a specific shell buffer index."
            (shell-pop--cd-to-cwd-eshell abspath))
           ((string= shell-pop-internal-mode "shell")
            (shell-pop--cd-to-cwd-shell abspath))
+          ((string= shell-pop-internal-mode "vterm")
+           (shell-pop--cd-to-cwd-vterm abspath))
+          ((string= shell-pop-internal-mode "eat")
+           (shell-pop--cd-to-cwd-eat abspath))
           (t
            (shell-pop--cd-to-cwd-term abspath)))))
 


### PR DESCRIPTION
- Added vterm and eat to the list of supported terminal implementations.
- Implemented shell-pop--cd-to-cwd-vterm and shell-pop--cd-to-cwd-eat to enable automatic directory synchronization.
- Updated shell-pop-check-internal-mode-buffer to verify that vterm and eat processes are active before reusing their buffers.
- Extended the shell-pop-shell-type customization variable with new options for vterm and eat.
- Updated README.md with detailed configuration examples and updated descriptions.