### PR TITLE
Eliminate visual flicker during window manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ To install **shell-pop** from MELPA:
   ;; If non-nil, the window stretches across the entire frame width.
   (shell-pop-full-span nil)
 
-  ;; The path to the shell executable used by the terminal emulator.
+  ;; The path to the shell executable used by the terminal emulator
+  ;; (e.g., "/usr/bin/env bash").
   (shell-pop-term-shell shell-file-name)
 
   ;; The height or width of the window as a percentage of the frame.
@@ -56,10 +57,9 @@ You can install `shell-pop.el` from [MELPA](https://melpa.org/) using `package.e
 M-x package-install RET shell-pop RET
 ```
 
-Make sure to place shell-pop.el somewhere in the load-path and add the following lines to your init file (e.g., `~/.emacs.d/init.el`):
+Then add the following to your init file (e.g., `~/.emacs.d/init.el`):
 
 ```lisp
-(add-to-list 'load-path "/path/to/shell-pop")
 (require 'shell-pop)
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ The percentage of the frame used for the shell buffer window size.
 
 This option allows you to generate the shell window with the same width as the current Emacs frame. It is beneficial when you use multiple side-by-side windows in Emacs. For more details, see [Issue #21](https://github.com/kyagi/shell-pop-el/pull/21#issuecomment-48876673).
 
+#### `shell-pop-default-directory` (Default: `nil`)
+
+If non-nil, changes the current directory to this specific path when first starting the shell.
+
+#### `shell-pop-term-shell` (Default: `explicit-shell-file-name`, the `ESHELL` environment variable, or `shell-file-name`)
+
+The path to the shell executable used by the `term` and `ansi-term` implementations (e.g., `"/bin/bash"` or `"/bin/zsh"`).
+
+#### `shell-pop-autocd-to-working-dir` (Default: `t`)
+
+If non-nil, automatically changes the directory of the shell buffer to match the working directory from which `shell-pop` was invoked.
+
+#### `shell-pop-restore-window-configuration` (Default: `t`)
+
+If non-nil, restores the window configuration when the `shell-pop` buffer is closed. The shell window is deleted in any case. This variable has no effect when the `shell-pop-window-position` value is `"full"`.
+
+#### `shell-pop-cleanup-buffer-at-process-exit` (Default: `t`)
+
+If non-nil, cleans up the shell's buffer automatically after its underlying process exits.
+
 ### Hooks
 
 - `shell-pop-in-hook`: Runs before the shell buffer pops up.

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -29,7 +29,7 @@
 ;; The shell-pop package provides on-demand access to a terminal through a
 ;; single, configurable key binding.
 ;;
-;; The package supports multiple terminal implementations, including term,
+;; The package supports multiple terminal implementations, including `term',
 ;; `eshell', `ansi-term', `vterm', and `eat', and ensures your original window
 ;; configuration is restored when the terminal is hidden.
 ;;
@@ -355,7 +355,8 @@ With prefix ARG, switch to or create a specific shell buffer index."
 (defun shell-pop--kill-and-delete-window ()
   "Kill the current shell buffer and safely delete its window."
   ;; Unified Eshell cleanup to mirror process-sentinel behavior exactly.
-  (let* ((buf (current-buffer))
+  (let* ((inhibit-redisplay t)
+         (buf (current-buffer))
          (win (get-buffer-window buf))
          (target-buf (when (window-live-p win)
                        (window-parameter win 'shell-pop-last-buffer))))
@@ -388,7 +389,8 @@ With prefix ARG, switch to or create a specific shell buffer index."
            (when (string-match-p "\\(?:finished\\|exited\\)" change)
              (run-hooks 'shell-pop-process-exit-hook)
 
-             (let* ((proc-buf (process-buffer proc))
+             (let* ((inhibit-redisplay t)
+                    (proc-buf (process-buffer proc))
                     ;; Safely get the window ONLY on the current frame
                     (proc-win (when (buffer-live-p proc-buf)
                                 (get-buffer-window proc-buf)))
@@ -453,7 +455,8 @@ With prefix ARG, switch to or create a specific shell buffer index."
 (defun shell-pop-up (index)
   "Pop up the shell buffer designated by INDEX."
   (run-hooks 'shell-pop-in-hook)
-  (let* ((w (if (listp index)
+  (let* ((inhibit-redisplay t)
+         (w (if (listp index)
                 (let ((ret (shell-pop-get-unused-internal-mode-buffer-window)))
                   (setq index (car ret))
                   (cdr ret))
@@ -498,13 +501,14 @@ With prefix ARG, switch to or create a specific shell buffer index."
     (when (and shell-pop-autocd-to-working-dir
                cwd
                (file-directory-p cwd))
-      (shell-pop--cd-to-cwd cwd))
-    (run-hooks 'shell-pop-in-after-hook)))
+      (shell-pop--cd-to-cwd cwd)))
+  (run-hooks 'shell-pop-in-after-hook))
 
 (defun shell-pop-out ()
   "Hide the shell pop-up buffer and restore the previous layout."
   (run-hooks 'shell-pop-out-hook)
-  (let* ((win (selected-window))
+  (let* ((inhibit-redisplay t)
+         (win (selected-window))
          (last-win (window-parameter win 'shell-pop-last-window))
          (last-buf (window-parameter win 'shell-pop-last-buffer))
          (win-conf (window-parameter win 'shell-pop-window-config)))


### PR DESCRIPTION
This sets inhibit-redisplay to t to window management functions (shell-pop-up,
shell-pop-out, shell-pop--kill-and-delete-window, and
shell-pop--set-exit-action).

Previously, shell-pop would render intermediate window states when splitting,
deleting, or resizing windows during a pop-up or pop-out action, causing a
noticeable visual flicker.

Performance benefits:
- Eliminates visual flickering.
- Reduces unnecessary CPU overhead by skipping intermediate layout calculations and display rendering cycles.
- Improves perceived snappiness and responsiveness on slower hardware or high-latency remote connections.
- Add more defcustom to the README.md file
