### PR TITLE
Remove needless kill-buffer call

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -383,10 +383,6 @@ With prefix ARG, switch to or create a specific shell buffer index."
          (last-win (when (window-live-p win)
                      (window-parameter win 'shell-pop-last-window))))
 
-    (when (and shell-pop-cleanup-buffer-at-process-exit
-               (buffer-live-p buf))
-      (kill-buffer buf))
-
     (when (window-live-p last-win)
       (set-window-parameter last-win 'shell-pop-is-caller nil))
 


### PR DESCRIPTION
eshell-exit-hook is called when eshell buffer is killed so calling kill-buffer in eshell-exit-hook causes the infinite-loop.

See #84.

#### NOTE

eshell-mode sets `(add-hook 'kill-buffer-hook #'eshell-kill-buffer-function t t)` and `eshell-kill-buffer-function` is as below(`eshell-kill-buffer-function` calls `eshell-exit-hook`). `kill-buffer` must not be called in this context.

```lisp
(defun eshell-kill-buffer-function ()
  "Function added to `kill-buffer-hook' in Eshell buffers.                                                                                                                                                            
This runs the function `eshell-kill-processes-on-exit',                                                                                                                                                               
and the hook `eshell-exit-hook'."
  ;; It's fine to run this unconditionally since it can be customized                                                                                                                                                 
  ;; via the `eshell-kill-processes-on-exit' variable.                                                                                                                                                                
  (and (fboundp 'eshell-query-kill-processes)
       (not (memq #'eshell-query-kill-processes eshell-exit-hook))
       (eshell-query-kill-processes))
  (run-hooks 'eshell-exit-hook))
```