### PR TITLE
Add `ghostel` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The **shell-pop** Emacs package provides on-demand access to a terminal through a single, configurable key binding.
 
-The package supports multiple terminal implementations, including `term`, `eshell`, `ansi-term`, `vterm`, and `eat`, and ensures your original window configuration is restored when the terminal is hidden.
+The package supports multiple terminal implementations, including `term`, `eshell`, `ansi-term`, `vterm`,`eat` and `ghostel`, and ensures your original window configuration is restored when the terminal is hidden.
 
 ## Installation
 
@@ -111,6 +111,20 @@ Here are the exact configurations for the most popular Emacs shells. Simply copy
                                      (eat shell-pop-term-shell))))))
 ```
 
+#### ghostel
+
+*Note: Requires the `ghostel` package to be installed.*
+
+```elisp
+(with-eval-after-load 'shell-pop
+  (setopt shell-pop-shell-type '("ghostel" "*ghostel*"
+                                 (lambda ()
+                                   (when (fboundp 'ghostel)
+                                     (let ((ghostel-shell shell-pop-term-shell))
+                                       (ghostel)))))))
+```
+
+
 #### Shell
 ```elisp
 (with-eval-after-load 'shell-pop
@@ -171,7 +185,7 @@ If non-nil, cleans up the shell's buffer automatically after its underlying proc
 
 ### M-x Customize
 
-Use `M-x customize-variable RET shell-pop-shell-type RET` to customize the shell to use. Six pre-set options are: `shell`, `terminal`, `ansi-term`, `eshell`, `vterm`, and `eat`. You can also set your custom shell if you use other configuration.
+Use `M-x customize-variable RET shell-pop-shell-type RET` to customize the shell to use. Six pre-set options are: `shell`, `terminal`, `ansi-term`, `eshell`, `vterm`, `eat` and `ghostel`. You can also set your custom shell if you use other configuration.
 
 For the `terminal` and `ansi-term` options, you can set the underlying shell by customizing `shell-pop-term-shell`. By default, `shell-file-name` is used, but you can also specify paths like `/bin/tcsh`, `/bin/bash`, or `/bin/zsh`.
 

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -30,14 +30,14 @@
 ;; single, configurable key binding.
 ;;
 ;; The package supports multiple terminal implementations, including `term',
-;; `eshell', `ansi-term', `vterm', and `eat', and ensures your original window
+;; `eshell', `ansi-term', `vterm', `eat' and `ghostel`, and ensures your original window
 ;; configuration is restored when the terminal is hidden.
 ;;
 ;; Configuration:
 ;; --------------
 ;; Use M-x customize-variable RET `shell-pop-shell-type' RET to customize the
 ;; shell to use. Six pre-set options are: `shell', `terminal', `ansi-term',
-;; `eshell', `vterm', and `eat'. You can also set your custom shell if you use
+;; `eshell', `vterm', `eat' and `ghostel'. You can also set your custom shell if you use
 ;; other configuration.
 ;;
 ;; For `terminal' and `ansi-term' options, you can set the underlying shell by
@@ -69,6 +69,9 @@
 (declare-function vterm-send-return "vterm")
 (declare-function eat "eat")
 (declare-function eat-term-send-string "eat")
+(declare-function ghostel "ghostel")
+(declare-function ghostel-send-string "ghostel")
+
 
 (defgroup shell-pop ()
   "Shell-pop."
@@ -160,7 +163,14 @@ The value is a list with these items:
                  ("eat" "*eat*"
                   (lambda ()
                     (when (fboundp 'eat)
-                      (eat shell-pop-term-shell))))))
+                      (eat shell-pop-term-shell)))))
+	  (const :tag "ghostel"
+                 ("ghostel" "*ghostel*"
+                  (lambda ()
+                    (when (fboundp 'ghostel)
+                      (let ((ghostel-shell shell-pop-term-shell))
+                        (ghostel))))))
+	  )
   :set 'shell-pop--set-shell-type
   :group 'shell-pop)
 
@@ -262,7 +272,7 @@ The input format is the same as that of `kbd'."
       (if (or (and (fboundp 'term-check-proc)
                    (term-check-proc bufname))
               (string= shell-pop-internal-mode "eshell")
-              (and (member shell-pop-internal-mode '("vterm" "eat"))
+              (and (member shell-pop-internal-mode '("vterm" "eat" "ghostel"))
                    (let ((proc (get-buffer-process bufname)))
                      (and proc (memq (process-status proc) '(run stop))))))
           bufname
@@ -349,6 +359,11 @@ With prefix ARG, switch to or create a specific shell buffer index."
       ;; Use the process object directly if eat-terminal isn't in scope
       (process-send-string proc (concat "cd " (shell-quote-argument cwd) "\nclear\n")))))
 
+(defun shell-pop--cd-to-cwd-ghostel (cwd)
+  "Change the terminal's directory to CWD and clear the screen in ghostel."
+  (when (fboundp 'ghostel-send-string)
+    (ghostel-send-string (concat "cd " (shell-quote-argument cwd) "\nclear\n"))))
+
 (defun shell-pop--cd-to-cwd (cwd)
   "Change the current working directory of the shell buffer to CWD."
   (let ((abspath (expand-file-name cwd)))
@@ -360,6 +375,8 @@ With prefix ARG, switch to or create a specific shell buffer index."
            (shell-pop--cd-to-cwd-vterm abspath))
           ((string= shell-pop-internal-mode "eat")
            (shell-pop--cd-to-cwd-eat abspath))
+          ((string= shell-pop-internal-mode "ghostel")
+           (shell-pop--cd-to-cwd-ghostel abspath))
           (t
            (shell-pop--cd-to-cwd-term abspath)))))
 


### PR DESCRIPTION
Just adding support for the ghostel terminal emulator.

`ghostel` a yet another emacs terminal emulator.
It is very similar to vterm, but uses a different library - libghostty-vt extracted from the Ghostty project.