### PR TITLE
Check internal mode buffer for shell

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -262,7 +262,7 @@ The input format is the same as that of `kbd'."
       (if (or (and (fboundp 'term-check-proc)
                    (term-check-proc bufname))
               (string= shell-pop-internal-mode "eshell")
-              (and (member shell-pop-internal-mode '("vterm" "eat"))
+              (and (member shell-pop-internal-mode '("shell" "vterm" "eat"))
                    (let ((proc (get-buffer-process bufname)))
                      (and proc (memq (process-status proc) '(run stop))))))
           bufname


### PR DESCRIPTION
I noticed a regression after updating `shell-pop` for the first time in ages.

When using shell-pop with a regular `shell.el` shell, everytime I un-pop my shell with the interactive `shell-pop` function, the shell buffer is deleted. The buffer is killed by the `shell-pop-check-internal-mode-buffer` function, as on my configuration I don't have `term` installed, and my `shell-pop-internal-mode` is `shell`. This means none of the conditions that prevent the buffer from being killed evaluate to true.

This PR updates `shell-pop-check-internal-mode-buffer` function to do the same process checking procedure for when `shell-pop-internal-mode` is `shell` that is already done for `vterm` and `eat`.
