### PR TITLE
Fix file-missing error when default-directory does not exist

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -550,11 +550,16 @@ buffer, falling back to the scratch buffer if that buffer is no longer alive."
     ;; "buffer poisoning" where the user's active code buffer gets its working
     ;; directory overwritten.
     (let ((default-directory
-           (if (and shell-pop-default-directory
-                    (file-directory-p shell-pop-default-directory))
-               (file-name-as-directory (expand-file-name
-                                        shell-pop-default-directory))
-             default-directory)))
+           (cond
+            ((and shell-pop-default-directory
+                  (file-directory-p shell-pop-default-directory))
+             (file-name-as-directory (expand-file-name
+                                      shell-pop-default-directory)))
+            ((and default-directory
+                  (file-directory-p default-directory))
+             default-directory)
+            (t
+             (expand-file-name "~/")))))
       (shell-pop--switch-to-shell-buffer index))
 
     ;; Save to the current window


### PR DESCRIPTION
When shell-pop is invoked from a buffer where the default-directory points to a non-existent path on the filesystem, initialization functions like vterm or shell fail with a file-missing error.

This patch updates shell-pop-up to validate that default-directory exists before binding it for shell-pop--switch-to-shell-buffer. If the directory does not exist, it safely falls back to the user's home directory.
