### PR TITLE
Add per-window and nested shell popups

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ The percentage of the frame used for the shell buffer window size.
 
 This option allows you to generate the shell window with the same width as the current Emacs frame. It is beneficial when you use multiple side-by-side windows in Emacs. For more details, see [Issue #21](https://github.com/kyagi/shell-pop-el/pull/21#issuecomment-48876673).
 
+#### `shell-pop-per-window` (Default: `nil`)
+
+If non-nil, toggles shell-pop separately for each source window. Invoking `shell-pop` from a non-shell window hides only the popup associated with that window, or creates one if none exists. This option has no effect when `shell-pop-full-span` is non-nil or when shell-pop uses a full-frame popup.
+
+#### `shell-pop-pop-under-shell` (Default: `nil`)
+
+If non-nil, invoking `shell-pop` with a prefix argument from an existing shell-pop window creates another popup instead of switching the current popup to the requested shell buffer. This option has no effect when `shell-pop-full-span` is non-nil.
+
 #### `shell-pop-default-directory` (Default: `nil`)
 
 If non-nil, changes the current directory to this specific path when first starting the shell.

--- a/shell-pop.el
+++ b/shell-pop.el
@@ -219,6 +219,27 @@ adjust the point automatically if it falls outside the new visible area."
   :type 'boolean
   :group 'shell-pop)
 
+(defcustom shell-pop-per-window nil
+  "If non-nil, toggle shell-pop separately for each source window.
+
+When this option is enabled, invoking `shell-pop' from a non-shell window hides
+only the popup associated with that window, or creates one if none exists.
+
+This option has no effect when `shell-pop-full-span' is non-nil or when
+shell-pop uses a full-frame popup."
+  :type 'boolean
+  :group 'shell-pop)
+
+(defcustom shell-pop-pop-under-shell nil
+  "If non-nil, popping another shell from a shell-pop window creates a new popup.
+
+When this option is nil, invoking `shell-pop' with a prefix argument from an
+existing shell-pop window switches that window to the requested shell buffer.
+
+This option has no effect when `shell-pop-full-span' is non-nil."
+  :type 'boolean
+  :group 'shell-pop)
+
 (defun shell-pop--set-universal-key (symbol value)
   "Set the universal key for `shell-pop' using SYMBOL and VALUE."
   (set-default symbol value)
@@ -294,34 +315,44 @@ With prefix ARG, switch to or create a specific shell buffer index."
   (when (and (minibufferp) (window-live-p (minibuffer-selected-window)))
     (select-window (minibuffer-selected-window)))
   (let* ((index (or arg shell-pop-last-shell-buffer-index))
+         (source-window (selected-window))
+         (per-window (shell-pop--per-window-p))
+         (popup-window (and per-window
+                            (null arg)
+                            (shell-pop--popup-window-for-source-window
+                             source-window index)))
          ;; Safely check for an existing window only if index is an integer. A
          ;; raw prefix arg like '(4) will bypass this and let shell-pop-up
          ;; handle it.
          (window (and (integerp index)
+                      (not per-window)
                       (shell-pop-get-internal-mode-buffer-window index))))
     ;; Scenario A: The user is already INSIDE a shell window
     (if (or shell-pop--is-shell-buffer
             (window-parameter nil 'shell-pop-is-window))
-        ;; No prefix (null arg): The user pressed a hotkey. It runs
-        ;; `shell-pop-out' to close the shell.
-        (if (null arg)
-            (shell-pop-out)
-          ;; If a prefix arg is provided while inside the shell: A raw C-u '(4)
-          ;; should find a new unused index dynamically. Otherwise, use the
-          ;; exact numeric prefix (e.g., M-2 -> 2).
-          (let ((target-index
-                 (if (listp arg)
-                     (car (shell-pop-get-unused-internal-mode-buffer-window))
-                   (prefix-numeric-value arg))))
-            (shell-pop--switch-to-shell-buffer target-index)))
+        (if (shell-pop--pop-under-shell-p)
+            (shell-pop--toggle-target-from-shell
+             (shell-pop--target-index arg))
+          ;; No prefix (null arg): The user pressed a hotkey. It runs
+          ;; `shell-pop-out' to close the shell.
+          (if (null arg)
+              (shell-pop-out)
+            ;; If a prefix arg is provided while inside the shell: A raw C-u '(4)
+            ;; should find a new unused index dynamically. Otherwise, use the
+            ;; exact numeric prefix (e.g., M-2 -> 2).
+            (shell-pop--switch-to-shell-buffer (shell-pop--target-index arg))))
       ;; Scenario B: The user is OUTSIDE the shell (e.g., in a code buffer)
-      (if (and window (null arg))
-          ;; The shell window (window) is visible somewhere else, and the user
-          ;; didn't pass a prefix, to that shell window and close it.
-          (progn
-            (select-window window)
-            (shell-pop-out))
-        (shell-pop-up index)))))
+      (cond
+       (popup-window
+        (select-window popup-window)
+        (shell-pop-out))
+       ((and window (null arg))
+        ;; The shell window (window) is visible somewhere else, and the user
+        ;; didn't pass a prefix, to that shell window and close it.
+        (select-window window)
+        (shell-pop-out))
+       (t
+        (shell-pop-up index))))))
 
 (defun shell-pop--cd-to-cwd-eshell (cwd)
   "Change the current working directory to CWD in eshell."
@@ -385,6 +416,55 @@ With prefix ARG, switch to or create a specific shell buffer index."
   "Return non-nil if the shell window should span fully."
   (or (string= shell-pop-window-position "full")
       (>= shell-pop-window-height 100)))
+
+(defun shell-pop--per-window-p ()
+  "Return non-nil when shell-pop should toggle per source window."
+  (and shell-pop-per-window
+       (not shell-pop-full-span)
+       (not (shell-pop--full-p))))
+
+(defun shell-pop--pop-under-shell-p ()
+  "Return non-nil when shell-pop should create popups from shell windows."
+  (and shell-pop-pop-under-shell
+       (not shell-pop-full-span)))
+
+(defun shell-pop--popup-window-for-source-window (source-window &optional index)
+  "Return the shell-pop window associated with SOURCE-WINDOW and INDEX, if any."
+  (when (window-live-p source-window)
+    (let ((bufname (and index (shell-pop--shell-buffer-name index))))
+      (catch 'found
+        (dolist (win (window-list (window-frame source-window) 'no-minibuf))
+          (when (and (window-parameter win 'shell-pop-is-window)
+                     (eq (window-parameter win 'shell-pop-last-window)
+                         source-window)
+                     (or (null bufname)
+                         (equal (buffer-name (window-buffer win)) bufname)))
+            (throw 'found win)))))))
+
+(defun shell-pop--target-index (arg)
+  "Return the shell-pop target index for prefix ARG."
+  (if arg
+      (if (listp arg)
+          (car (shell-pop-get-unused-internal-mode-buffer-window))
+        (prefix-numeric-value arg))
+    shell-pop-last-shell-buffer-index))
+
+(defun shell-pop--toggle-target-from-shell (index)
+  "Toggle shell-pop buffer INDEX from the selected shell-pop window."
+  (setq shell-pop-last-shell-buffer-index index)
+  (let ((bufname (shell-pop--shell-buffer-name index))
+        (target-window (if (shell-pop--per-window-p)
+                           (shell-pop--popup-window-for-source-window
+                            (selected-window) index)
+                         (shell-pop-get-internal-mode-buffer-window index))))
+    (cond
+     ((equal (buffer-name) bufname)
+      (shell-pop-out))
+     (target-window
+      (select-window target-window)
+      (shell-pop-out))
+     (t
+      (shell-pop-up index)))))
 
 (defsubst shell-pop--split-side-p ()
   "Return non-nil if the shell window should be split on the side."
@@ -512,15 +592,17 @@ buffer, falling back to the scratch buffer if that buffer is no longer alive."
   "Pop up the shell buffer designated by INDEX."
   (run-hooks 'shell-pop-in-hook)
   (let* ((inhibit-redisplay t)
-         (win (if (listp index)
-                  (let ((ret (shell-pop-get-unused-internal-mode-buffer-window)))
-                    (setq index (car ret))
-                    (cdr ret))
-                (shell-pop-get-internal-mode-buffer-window index)))
          (cwd (when default-directory
                 (replace-regexp-in-string "\\\\" "/" default-directory)))
          (last-buf (current-buffer))
          (last-win (selected-window))
+         (win (if (listp index)
+                  (let ((ret (shell-pop-get-unused-internal-mode-buffer-window)))
+                    (setq index (car ret))
+                    (cdr ret))
+                (if (shell-pop--per-window-p)
+                    (shell-pop--popup-window-for-source-window last-win index)
+                  (shell-pop-get-internal-mode-buffer-window index))))
          ;; Capture these BEFORE switching windows
          (win-start (window-start last-win))
          (win-hscroll (window-hscroll last-win))


### PR DESCRIPTION
Hi, I really enjoy shell-pop and appreciate the active development that has been happening! This PR adds two opt-in variables for controlling how shell-pop behaves across multiple windows and shell buffers. These are features I've always wanted and finally got around to implementing.

### New options

- `shell-pop-per-window`
- `shell-pop-pop-under-shell`

`shell-pop-per-window` makes popup state local to the source window. When enabled, invoking `shell-pop` from a non-shell window toggles the popup associated with that window instead of closing or selecting a shell popup that is visible elsewhere. If the window layout changes while a popup is open, shell-pop only restores the original window when it is still available. It will not restore into some unrelated window.

`shell-pop-pop-under-shell` allows prefix-invoking `shell-pop` from an existing shell-pop window to create another popup instead of replacing the current popup’s buffer. For example, invoking shell 2 from shell 1 can display shell 2 in a new popup while leaving shell 1 visible.

Both options are disabled by default and can be enabled independently or together. `shell-pop-per-window` has no effect with full-span or full-frame popups, and `shell-pop-pop-under-shell` has no effect when `shell-pop-full-span` is enabled.

I tested the default behavior, combinations of the new options, different popup positions, restore modes, and window layout changes. Everything looked good in my testing, but since this project does not currently have a test suite, extra review around the window-management changes would be very appreciated.
