### PR TITLE
Remove the eval anti-pattern in shell-pop--switch-to-shell-buffer

### DIFF
--- a/shell-pop.el
+++ b/shell-pop.el
@@ -551,7 +551,7 @@ buffer, falling back to the scratch buffer if that buffer is no longer alive."
   (let ((bufname (shell-pop--shell-buffer-name index)))
     (if (get-buffer bufname)
         (switch-to-buffer bufname)
-      (funcall (eval shell-pop-internal-mode-func))
+      (funcall shell-pop-internal-mode-func)
       (rename-buffer bufname)
       (shell-pop--set-exit-action))
     (setq shell-pop--is-shell-buffer t)


### PR DESCRIPTION
Remove the eval anti-pattern in shell-pop--switch-to-shell-buffer